### PR TITLE
Add energy monitoring support for KP125M

### DIFF
--- a/src/nodes/tplink_tapo_connect_wrapper/tplink_tapo_connect_wrapper.ts
+++ b/src/nodes/tplink_tapo_connect_wrapper/tplink_tapo_connect_wrapper.ts
@@ -8,6 +8,7 @@ import { tplinkTapoConnectWrapperType } from './type'
 const supportEnergyUsage = [
      "P110"
     ,"P115"
+    ,"KP125M"
 ];
 
 /**


### PR DESCRIPTION
Added support for KP125M.

Verified and tested with KP125M switch for energy monitoring.  